### PR TITLE
Extend Bulk/Sync Selection Logic to Include Indirect Operations

### DIFF
--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -93,7 +93,7 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
     } else if (gpio.parameters.at("type") == "sensor") {
       sensor_id_.push_back(static_cast<uint8_t>(stoi(gpio.parameters.at("ID"))));
     } else {
-      RCLCPP_ERROR_STREAM(logger_, "Invalid DXL / Sensoe type");
+      RCLCPP_ERROR_STREAM(logger_, "Invalid DXL / Sensor type");
       exit(-1);
     }
   }


### PR DESCRIPTION
## Changes
This PR extends the existing automatic bulk/sync selection logic to properly handle indirect read/write operations:

1. Enhanced Selection Logic for Indirect Operations
   - Previously: The system only checked regular read/write items to determine bulk vs sync operations
   - Now: Added checks for indirect addresses and sizes when determining operation type
   - System will switch to bulk operations when indirect addresses or sizes differ between Dynamixels
   - Maintains existing logic for regular read/write operations

2. Error Message Fix
   - Fixed typo in DXL/Sensor type validation error message

## Why
- The previous implementation didn't consider indirect operations in its bulk/sync decision logic
- This could lead to incorrect operation selection when Dynamixels had different indirect configurations

## Technical Details
- Existing bulk/sync selection logic preserved for regular operations
- New checks added specifically for:
  - Indirect address consistency across Dynamixels
  - Indirect data size consistency across Dynamixels
- Bulk operations are now correctly chosen when indirect configurations vary