### PR TITLE
Enhance Error Handling and Timeout Management

### DIFF
--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -181,7 +181,12 @@ private:
   std::map<uint8_t /*id*/, uint8_t /*err*/> dxl_hw_err_;
   DxlTorqueStatus dxl_torque_status_;
   std::map<uint8_t /*id*/, bool /*enable*/> dxl_torque_state_;
-  double err_timeout_sec_;
+  double err_timeout_ms_;
+  rclcpp::Duration read_error_duration_{0, 0};
+  rclcpp::Duration write_error_duration_{0, 0};
+  bool is_read_in_error_{false};
+  bool is_write_in_error_{false};
+
   bool use_revolute_to_prismatic_{false};
   std::string conversion_dxl_name_{""};
   std::string conversion_joint_name_{""};

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -35,7 +35,11 @@ DynamixelHardware::DynamixelHardware()
 {
   dxl_status_ = DXL_OK;
   dxl_torque_status_ = TORQUE_ENABLED;
-  err_timeout_sec_ = 3.0;
+  err_timeout_ms_ = 500;
+  is_read_in_error_ = false;
+  is_write_in_error_ = false;
+  read_error_duration_ = rclcpp::Duration(0, 0);
+  write_error_duration_ = rclcpp::Duration(0, 0);
 }
 
 DynamixelHardware::~DynamixelHardware()
@@ -64,7 +68,7 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
 
   port_name_ = info_.hardware_parameters["port_name"];
   baud_rate_ = info_.hardware_parameters["baud_rate"];
-  err_timeout_sec_ = stod(info_.hardware_parameters["error_timeout_sec"]);
+  err_timeout_ms_ = stod(info_.hardware_parameters["error_timeout_ms"]);
 
   RCLCPP_INFO_STREAM(
     logger_,
@@ -394,11 +398,23 @@ hardware_interface::return_type DynamixelHardware::read(
   } else if (dxl_status_ == DXL_OK || dxl_status_ == COMM_ERROR) {
     dxl_comm_err_ = CheckError(dxl_comm_->ReadMultiDxlData());
     if (dxl_comm_err_ != DxlError::OK) {
+      if (!is_read_in_error_) {
+        is_read_in_error_ = true;
+        read_error_duration_ = rclcpp::Duration(0, 0);
+      }
+      read_error_duration_ = read_error_duration_ + period;
+      
       RCLCPP_ERROR_STREAM(
         logger_,
-        "Dynamixel Read Fail :" << Dynamixel::DxlErrorToString(dxl_comm_err_));
-      return hardware_interface::return_type::ERROR;
+        "Dynamixel Read Fail (Duration: " << read_error_duration_.seconds() * 1000 << "ms/" << err_timeout_ms_ << "ms)");
+
+      if (read_error_duration_.seconds() * 1000 >= err_timeout_ms_) {
+        return hardware_interface::return_type::ERROR;
+      }
+      return hardware_interface::return_type::OK;
     }
+    is_read_in_error_ = false;
+    read_error_duration_ = rclcpp::Duration(0, 0);
   } else if (dxl_status_ == HW_ERROR) {
     dxl_comm_err_ = CheckError(dxl_comm_->ReadMultiDxlData());
     if (dxl_comm_err_ != DxlError::OK) {
@@ -434,7 +450,6 @@ hardware_interface::return_type DynamixelHardware::read(
   }
   return hardware_interface::return_type::OK;
 }
-
 hardware_interface::return_type DynamixelHardware::write(
   const rclcpp::Time & time, const rclcpp::Duration & period)
 {
@@ -447,16 +462,28 @@ hardware_interface::return_type DynamixelHardware::write(
 
     dxl_comm_->WriteMultiDxlData();
 
+    is_write_in_error_ = false;
+    write_error_duration_ = rclcpp::Duration(0, 0);
+
     return hardware_interface::return_type::OK;
   } else {
-    RCLCPP_ERROR_STREAM(logger_, "Dynamixel Write Fail");
-    return hardware_interface::return_type::ERROR;
+    write_error_duration_ = write_error_duration_ + period;
+    
+    RCLCPP_ERROR_STREAM(
+      logger_,
+      "Dynamixel Write Fail (Duration: " << write_error_duration_.seconds() * 1000 << "ms/" << err_timeout_ms_ << "ms)");
+
+    if (write_error_duration_.seconds() * 1000 >= err_timeout_ms_) {
+      return hardware_interface::return_type::ERROR;
+    }
+    return hardware_interface::return_type::OK;
   }
 }
 
 DxlError DynamixelHardware::CheckError(DxlError dxl_comm_err)
 {
   DxlError error_state = DxlError::OK;
+  dxl_status_ = DXL_OK;
 
   // check comm error
   if (dxl_comm_err != DxlError::OK) {

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -68,7 +68,11 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
 
   port_name_ = info_.hardware_parameters["port_name"];
   baud_rate_ = info_.hardware_parameters["baud_rate"];
-  err_timeout_ms_ = stod(info_.hardware_parameters["error_timeout_ms"]);
+  try {
+    err_timeout_ms_ = stod(info_.hardware_parameters["error_timeout_ms"]);
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(logger_, "Failed to parse error_timeout_ms parameter: %s, using default value", e.what());
+  }
 
   RCLCPP_INFO_STREAM(
     logger_,


### PR DESCRIPTION
This PR improves the error handling and timeout management in the Dynamixel Hardware Interface.

### Changes

1. **Enhanced Error State Management**
   - Changed timeout unit from seconds to milliseconds for finer control.
   - Added new state tracking variables:
     ```cpp
     rclcpp::Duration read_error_duration_{0, 0};
     rclcpp::Duration write_error_duration_{0, 0};
     bool is_read_in_error_{false};
     bool is_write_in_error_{false};
     ```
   - Implemented progressive error handling:
     - Tracks error duration for both read and write operations.
     - Only fails after reaching the timeout threshold.
     - Provides detailed error duration logging.

2. **Timeout-Based Approach to Prevent Single-Point Failure**
   - Previously, a single communication error would cause the entire system to fail. This change introduces a timeout-based mechanism to ensure that temporary or isolated communication errors do not lead to system-wide failure.

### Implementation Details
- Default timeout changed to **500ms**.
- Error durations are tracked separately for read and write operations (this distinction does not have a significant meaning but allows better tracking).
- Error states are reset upon successful operations.
- Enhanced error logging now includes duration and threshold details.
- Improved error recovery mechanisms for a more robust system.

### Why
**More Resilient Error Handling**
   - Provides graceful degradation instead of immediate failure.
   - Enables recovery from temporary communication issues while maintaining overall system stability.

Let me know if you need any clarification or have questions about the implementation.