### PR TITLE
Use GroupFastSyncRead and GroupFastBulkRead

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,6 @@ ROS 2 package providing a hardware interface for controlling [Dynamixel](https:/
 
 This package currently supports ROS 2 Humble only. Ensure that ROS 2 Humble is properly installed (ROS 2 Humble installation guide).
 
-- [Dynamixel SDK](https://github.com/ROBOTIS-GIT/DynamixelSDK):
-  - Install the Dynamixel SDK using the following command:
-
-    ```bash
-    sudo apt install ros-humble-dynamixel-sdk
-    ```
-
 - Hardware Requirements:
 
   - Dynamixel servos
@@ -31,6 +24,7 @@ This package currently supports ROS 2 Humble only. Ensure that ROS 2 Humble is p
 
    ```bash
    cd ~/${WORKSPACE}/src
+   git clone -b humble https://github.com/ROBOTIS-GIT/DynamixelSDK.git
    git clone -b humble https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface.git
    git clone -b humble https://github.com/ROBOTIS-GIT/dynamixel_interfaces.git
    ```

--- a/include/dynamixel_hardware_interface/dynamixel/dynamixel.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel/dynamixel.hpp
@@ -125,12 +125,12 @@ private:
   std::vector<RWItemList> read_data_list_;
 
   // sync read
-  dynamixel::GroupSyncRead * group_sync_read_;
+  dynamixel::GroupFastSyncRead * group_sync_read_;
   // indirect inform for sync read
   std::map<uint8_t /*id*/, IndirectInfo> indirect_info_read_;
 
   // bulk read
-  dynamixel::GroupBulkRead * group_bulk_read_;
+  dynamixel::GroupFastBulkRead * group_bulk_read_;
 
   // write item (sync or bulk) variable
   bool write_type_;

--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -799,7 +799,7 @@ DxlError Dynamixel::SetSyncReadHandler(std::vector<uint8_t> id_arr)
     IN_ADDR, indirect_info_read_[id_arr.at(0)].size);
 
   group_sync_read_ =
-    new dynamixel::GroupSyncRead(
+    new dynamixel::GroupFastSyncRead(
     port_handler_, packet_handler_,
     IN_ADDR, indirect_info_read_[id_arr.at(0)].size);
 
@@ -917,7 +917,7 @@ DxlError Dynamixel::SetBulkReadHandler(std::vector<uint8_t> id_arr)
       IN_ADDR, indirect_info_read_[id_arr.at(0)].size);
   }
 
-  group_bulk_read_ = new dynamixel::GroupBulkRead(port_handler_, packet_handler_);
+  group_bulk_read_ = new dynamixel::GroupFastBulkRead(port_handler_, packet_handler_);
 
   for (auto it_id : id_arr) {
     uint8_t ID = it_id;


### PR DESCRIPTION
# Improved Communication Performance with Fast Sync/Bulk Read Implementation

This PR enhances the communication performance of the Dynamixel Hardware Interface by implementing Fast Sync/Bulk Read operations.

### Changes

1. **Upgraded Read Operations**
   - Changed from standard `GroupSyncRead` to `GroupFastSyncRead`
   - Changed from standard `GroupBulkRead` to `GroupFastBulkRead`
   - Updated class member declarations:
     ```cpp
     // Before
     dynamixel::GroupSyncRead * group_sync_read_;
     dynamixel::GroupBulkRead * group_bulk_read_;
     
     // After
     dynamixel::GroupFastSyncRead * group_sync_read_;
     dynamixel::GroupFastBulkRead * group_bulk_read_;
     ```

2. **Performance Benefits**
   - Faster communication speed for multi-device read operations
   - Reduced communication overhead

### Implementation Details
- The change is implemented at the low-level communication layer
- All higher-level functionality remains unchanged

Please review and let me know if you need any clarification or have suggestions for improvement.