### PR TITLE
Improve Dynamixel initialization with torque disable

### DIFF
--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -79,9 +79,14 @@ DxlError Dynamixel::InitDxlComm(
       return DxlError::CANNOT_FIND_CONTROL_ITEM;
     } else {
       fprintf(stderr, " - Ping succeeded. Dynamixel model number : %d\n", dxl_model_number);
+      dxl_info_.ReadDxlModelFile(it_id, dxl_model_number);
+      // Disable torque
+      if (WriteItem(it_id, "Torque Enable", TORQUE_OFF) < 0) {
+        fprintf(stderr, "[ID:%03d] Cannot write \"Torque Off\" command!\n", it_id);
+        return DxlError::ITEM_WRITE_FAIL;
+      }
+      fprintf(stderr, "[ID:%03d] Torque OFF\n", it_id);
     }
-
-    dxl_info_.ReadDxlModelFile(it_id, dxl_model_number);
   }
 
   read_data_list_.clear();


### PR DESCRIPTION
### Changes  

1. **Modify `InitDxlComm` to Disable Torque During Initialization**  
   - After reading the model file, torque is explicitly disabled to prevent unintended movements.  
   - Ensures that the Dynamixel is writable for further operations.  

2. **Enhance Initialization Stability**  
   - Prevents potential issues caused by an active torque state during configuration.  
   - Improves safety by ensuring proper control over Dynamixel settings before enabling torque.  

### Implementation Details  
- Torque is disabled immediately after reading the model file.  
- This change allows smoother transitions during initialization without interference from active torque.  
- Ensures the Dynamixel remains in a safe and configurable state before proceeding with further operations.  

### Why  
**Better Initialization Control & Safety**  
- Prevents unexpected movements when setting up Dynamixel parameters.  
- Allows safe and controlled parameter adjustments before enabling torque.  

Let me know if any refinements are needed! 🚀