### PR TITLE
Remove deprecated parameter `ros_update_freq_` to prevent `stoi` failure

### DIFF
--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -327,8 +327,6 @@ private:
   double revoluteToPrismatic(double revolute_value);
 
   double prismaticToRevolute(double prismatic_value);
-
-  int ros_update_freq_;
 };
 
 }  // namespace dynamixel_hardware_interface

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -277,8 +277,6 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
     str_set_dxl_torque_srv_name,
     std::bind(&DynamixelHardware::set_dxl_torque_srv_callback, this, _1, _2));
 
-  ros_update_freq_ = stoi(info_.hardware_parameters["ros_update_freq"]);
-
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
### Changes  

1. **Removed Deprecated Parameter `ros_update_freq_`**  
   - Eliminated usage of `ros_update_freq_`, which is no longer required.  
   - Prevents issues when `ros2_control.urdf` does not include this parameter.  

2. **Fixed Potential `stoi` Failure**  
   - Previously, if `ros_update_freq_` was missing from `ros2_control.urdf`, the system could encounter a `std::stoi` conversion failure.  
   - The removal of this parameter ensures robustness against missing configurations.  

### Implementation Details  
- All references to `ros_update_freq_` have been removed from the codebase.  
- Updated logic to ensure safe execution without relying on this parameter.  

### Why  

**Prevents Runtime Failures & Improves Stability**  
- Eliminates potential `stoi` errors when the parameter is absent in `ros2_control.urdf`.  
- Ensures a more resilient and predictable system configuration.  

Let me know if any refinements are needed! 🚀