### PR TITLE
Support Current Control

### DIFF
--- a/include/dynamixel_hardware_interface/dynamixel/dynamixel_info.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel/dynamixel_info.hpp
@@ -78,7 +78,8 @@ public:
     int32_t & value_of_max_radian_position,
     int32_t & value_of_min_radian_position,
     double & min_radian,
-    double & max_radian);
+    double & max_radian,
+    double & torque_constant);
   int32_t ConvertRadianToValue(uint8_t id, double radian);
   double ConvertValueToRadian(uint8_t id, int32_t value);
   inline int16_t ConvertEffortToCurrent(uint8_t id, double effort)

--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -47,6 +47,10 @@
 #define PRESENT_VELOCITY_INDEX 1
 #define PRESENT_EFFORT_INDEX 2
 
+#define GOAL_POSITION_INDEX 0
+// #define GOAL_VELOCITY_INDEX 1  // TODO: to be implemented
+#define GOAL_CURRENT_INDEX 1
+
 namespace dynamixel_hardware_interface
 {
 

--- a/param/dxl_model/xc330_t181.model
+++ b/param/dxl_model/xc330_t181.model
@@ -5,6 +5,7 @@ value_of_max_radian_position	4095
 value_of_min_radian_position	0
 min_radian	-3.14159265
 max_radian	3.14159265
+torque_constant	0.0006709470296015791
 
 [control table]
 Address	Size	Data Name

--- a/param/dxl_model/xc330_t288.model
+++ b/param/dxl_model/xc330_t288.model
@@ -5,6 +5,7 @@ value_of_max_radian_position	4095
 value_of_min_radian_position	0
 min_radian	-3.14159265
 max_radian	3.14159265
+torque_constant	0.0009674796739867748
 
 [control table]
 Address	Size	Data Name

--- a/param/dxl_model/xh540_w150.model
+++ b/param/dxl_model/xh540_w150.model
@@ -5,6 +5,7 @@ value_of_max_radian_position	4095
 value_of_min_radian_position	0
 min_radian	-3.14159265
 max_radian	3.14159265
+torque_constant	0.0045
 
 [control table]
 Address	Size	Data Name

--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -840,7 +840,7 @@ DxlError Dynamixel::GetDxlValueFromSyncRead()
           dxl_info_.ConvertValueRPMToVelocityRPS(ID, static_cast<int32_t>(dxl_getdata));
       } else if (indirect_info_read_[ID].item_name.at(item_index) == "Present Current") {
         *it_read_data.item_data_ptr_vec.at(item_index) =
-          static_cast<int16_t>(dxl_getdata);
+         dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
       } else {
         *it_read_data.item_data_ptr_vec.at(item_index) =
           static_cast<double>(dxl_getdata);
@@ -962,7 +962,7 @@ DxlError Dynamixel::GetDxlValueFromBulkRead()
           dxl_info_.ConvertValueRPMToVelocityRPS(ID, static_cast<int32_t>(dxl_getdata));
       } else if (indirect_info_read_[ID].item_name.at(item_index) == "Present Current") {
         *it_read_data.item_data_ptr_vec.at(item_index) =
-          static_cast<int16_t>(dxl_getdata);
+         dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
       } else {
         *it_read_data.item_data_ptr_vec.at(item_index) =
           static_cast<double>(dxl_getdata);

--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -840,7 +840,7 @@ DxlError Dynamixel::GetDxlValueFromSyncRead()
           dxl_info_.ConvertValueRPMToVelocityRPS(ID, static_cast<int32_t>(dxl_getdata));
       } else if (indirect_info_read_[ID].item_name.at(item_index) == "Present Current") {
         *it_read_data.item_data_ptr_vec.at(item_index) =
-         dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
+          dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
       } else {
         *it_read_data.item_data_ptr_vec.at(item_index) =
           static_cast<double>(dxl_getdata);
@@ -962,7 +962,7 @@ DxlError Dynamixel::GetDxlValueFromBulkRead()
           dxl_info_.ConvertValueRPMToVelocityRPS(ID, static_cast<int32_t>(dxl_getdata));
       } else if (indirect_info_read_[ID].item_name.at(item_index) == "Present Current") {
         *it_read_data.item_data_ptr_vec.at(item_index) =
-         dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
+          dxl_info_.ConvertCurrentToEffort(ID, static_cast<int16_t>(dxl_getdata));
       } else {
         *it_read_data.item_data_ptr_vec.at(item_index) =
           static_cast<double>(dxl_getdata);

--- a/src/dynamixel/dynamixel_info.cpp
+++ b/src/dynamixel/dynamixel_info.cpp
@@ -149,13 +149,15 @@ bool DynamixelInfo::GetDxlTypeInfo(
   int32_t & value_of_max_radian_position,
   int32_t & value_of_min_radian_position,
   double & min_radian,
-  double & max_radian)
+  double & max_radian,
+  double & torque_constant)
 {
   value_of_zero_radian_position = dxl_info_[id].value_of_zero_radian_position;
   value_of_max_radian_position = dxl_info_[id].value_of_max_radian_position;
   value_of_min_radian_position = dxl_info_[id].value_of_min_radian_position;
   min_radian = dxl_info_[id].min_radian;
   max_radian = dxl_info_[id].max_radian;
+  torque_constant = dxl_info_[id].torque_constant;
   return true;
 }
 

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -711,15 +711,21 @@ bool DynamixelHardware::InitDxlWriteItems()
     for (const hardware_interface::ComponentInfo & gpio : info_.gpios) {
       if (gpio.command_interfaces.size()) {
         uint8_t id = static_cast<uint8_t>(stoi(gpio.parameters.at("ID")));
-        for (auto it : gpio.command_interfaces) {
         HandlerVarType temp_write;
         temp_write.id = id;
         temp_write.name = gpio.name;
 
-          temp_write.interface_name_vec.push_back(it.name);
+        temp_write.interface_name_vec.push_back("Goal Position");
         temp_write.value_ptr_vec.push_back(std::make_shared<double>(0.0));
-        hdl_trans_commands_.push_back(temp_write);
+
+        for (auto it : gpio.command_interfaces) {
+          if (it.name == "Goal Current") {
+            temp_write.interface_name_vec.push_back("Goal Current");
+            temp_write.value_ptr_vec.push_back(std::make_shared<double>(0.0));
+          }
         }
+
+        hdl_trans_commands_.push_back(temp_write);
       }
     }
     is_set_hdl = true;

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -870,10 +870,8 @@ void DynamixelHardware::CalcJointToTransmission()
 
   for (size_t i = 0; i < num_of_transmissions_; i++) {
     if(hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
-      hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current")
-    {
-      for(size_t j = 0; j < hdl_joint_commands_.size(); j++)
-      {
+      hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current") {
+      for(size_t j = 0; j < hdl_joint_commands_.size(); j++) {
         if(hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
           hdl_joint_commands_.at(j).interface_name_vec.at(GOAL_CURRENT_INDEX) ==
           hardware_interface::HW_IF_EFFORT)

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -712,13 +712,13 @@ bool DynamixelHardware::InitDxlWriteItems()
       if (gpio.command_interfaces.size()) {
         uint8_t id = static_cast<uint8_t>(stoi(gpio.parameters.at("ID")));
         for (auto it : gpio.command_interfaces) {
-          HandlerVarType temp_write;
-          temp_write.id = id;
-          temp_write.name = gpio.name;
+        HandlerVarType temp_write;
+        temp_write.id = id;
+        temp_write.name = gpio.name;
 
           temp_write.interface_name_vec.push_back(it.name);
-          temp_write.value_ptr_vec.push_back(std::make_shared<double>(0.0));
-          hdl_trans_commands_.push_back(temp_write);
+        temp_write.value_ptr_vec.push_back(std::make_shared<double>(0.0));
+        hdl_trans_commands_.push_back(temp_write);
         }
       }
     }
@@ -853,14 +853,22 @@ void DynamixelHardware::CalcJointToTransmission()
     double value = 0.0;
     for (size_t j = 0; j < num_of_joints_; j++) {
       value += joint_to_transmission_matrix_[i][j] *
-        (*hdl_joint_commands_.at(j).value_ptr_vec.at(0));
+        (*hdl_joint_commands_.at(j).value_ptr_vec.at(GOAL_POSITION_INDEX));
     }
 
     if (hdl_trans_commands_.at(i).name == conversion_dxl_name_) {
       value = prismaticToRevolute(value);
     }
+    *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_POSITION_INDEX) = value;
+  }
 
-    *hdl_trans_commands_.at(i).value_ptr_vec.at(0) = value;
+  for (size_t i = 0; i < num_of_transmissions_; i++) {
+    double value = 0.0;
+    for (size_t j = 0; j < num_of_joints_; j++) {
+      value += joint_to_transmission_matrix_[i][j] *
+        (*hdl_joint_commands_.at(j).value_ptr_vec.at(GOAL_CURRENT_INDEX));
+    }
+    *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_CURRENT_INDEX) = value;
   }
 }
 

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -869,12 +869,18 @@ void DynamixelHardware::CalcJointToTransmission()
   }
 
   for (size_t i = 0; i < num_of_transmissions_; i++) {
-    double value = 0.0;
-    for (size_t j = 0; j < num_of_joints_; j++) {
-      value += joint_to_transmission_matrix_[i][j] *
-        (*hdl_joint_commands_.at(j).value_ptr_vec.at(GOAL_CURRENT_INDEX));
+    if(hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX && hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current")
+    {
+      double value = 0.0;
+      for (size_t j = 0; j < num_of_joints_; j++) {
+        if(hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX && hdl_joint_commands_.at(j).interface_name_vec.at(GOAL_CURRENT_INDEX) == hardware_interface::HW_IF_EFFORT)
+        {
+          value += joint_to_transmission_matrix_[i][j] *
+            (*hdl_joint_commands_.at(j).value_ptr_vec.at(GOAL_CURRENT_INDEX));
+        }
+      }
+      *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_CURRENT_INDEX) = value;
     }
-    *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_CURRENT_INDEX) = value;
   }
 }
 

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -869,17 +869,23 @@ void DynamixelHardware::CalcJointToTransmission()
   }
 
   for (size_t i = 0; i < num_of_transmissions_; i++) {
-    if(hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX && hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current")
+    if(hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
+      hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current")
     {
-      double value = 0.0;
-      for (size_t j = 0; j < num_of_joints_; j++) {
-        if(hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX && hdl_joint_commands_.at(j).interface_name_vec.at(GOAL_CURRENT_INDEX) == hardware_interface::HW_IF_EFFORT)
+      for(size_t j = 0; j < hdl_joint_commands_.size(); j++)
+      {
+        if(hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
+          hdl_joint_commands_.at(j).interface_name_vec.at(GOAL_CURRENT_INDEX) ==
+          hardware_interface::HW_IF_EFFORT)
         {
-          value += joint_to_transmission_matrix_[i][j] *
-            (*hdl_joint_commands_.at(j).value_ptr_vec.at(GOAL_CURRENT_INDEX));
+          double value = 0.0;
+          for (size_t k = 0; k < num_of_joints_; k++) {
+            value += joint_to_transmission_matrix_[i][k] *
+              (*hdl_joint_commands_.at(k).value_ptr_vec.at(GOAL_CURRENT_INDEX));
+          }
+          *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_CURRENT_INDEX) = value;
         }
       }
-      *hdl_trans_commands_.at(i).value_ptr_vec.at(GOAL_CURRENT_INDEX) = value;
     }
   }
 }

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -869,10 +869,11 @@ void DynamixelHardware::CalcJointToTransmission()
   }
 
   for (size_t i = 0; i < num_of_transmissions_; i++) {
-    if(hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
-      hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current") {
-      for(size_t j = 0; j < hdl_joint_commands_.size(); j++) {
-        if(hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
+    if (hdl_trans_commands_.at(i).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
+      hdl_trans_commands_.at(i).interface_name_vec.at(GOAL_CURRENT_INDEX) == "Goal Current")
+    {
+      for (size_t j = 0; j < hdl_joint_commands_.size(); j++) {
+        if (hdl_joint_commands_.at(j).interface_name_vec.size() > GOAL_CURRENT_INDEX &&
           hdl_joint_commands_.at(j).interface_name_vec.at(GOAL_CURRENT_INDEX) ==
           hardware_interface::HW_IF_EFFORT)
         {


### PR DESCRIPTION
## Changes

1. **Add Torque Constant Parameter to DXL Model Files**
   - Introduced 'torque_constant' parameter to xc330_t181.model, xc330_t288.model, and xh540_w150.model
   - Added specific torque constant values for each model:
     - xc330_t181: 0.0006709470296015791
     - xc330_t288: 0.0009674796739867748
     - xh540_w150: 0.0045

2. **Enhance Transmission Command Calculation**
   - Improved handling of 'Goal Current' interface in transmission commands
   - Added conditional checks for interface names before accumulating values
   - Ensures proper validation of hardware interface types

3. **Unified Initialization Structure**
   - Refactored initialization code for better organization
   - Standardized command interface handling
   - Improved support for multiple command interfaces

4. **Support for Goal Current Control**
   - Added support for 'Goal Current' control in OpenMANIPULATOR-Y
   - Introduced new models: xh540_w150 and xc330_t288
   - Enhanced current-to-effort conversion functionality

## Implementation Details
- Added torque constant parameter to model files for accurate torque calculations
- Implemented proper interface validation in transmission command calculations
- Unified the structure of initialization code for better maintainability
- Enhanced current control support with proper conversion functions

## Why
**Improved Control and Compatibility**
- Enables more precise torque control through accurate torque constants
- Provides better support for current-based control mode
- Improves code organization and maintainability
- Ensures proper validation of hardware interfaces

Let me know if any refinements are needed! 🚀 