### PR TITLE
Update error timeout parameter in README from seconds to millisecond

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ These parameters define how the interface communicates with the Dynamixel motors
 
 - **`baud_rate`**: Communication baud rate.
 
-- **`error_timeout_sec`**: Timeout for communication errors.
+- **`error_timeout_ms`**: Timeout for communication errors.
 
 #### **2. Hardware Configuration**
 


### PR DESCRIPTION
## Changes

1. **Update Communication Timeout Parameter in README**
   - Modified the README documentation to change **`error_timeout_sec`** to **`error_timeout_ms`**.
   - This change clarifies that the timeout for communication errors is specified in milliseconds, not seconds.

## Implementation Details
- Updated the README file to reflect the correct unit for the error timeout parameter.
- Ensured consistency between documentation and code implementation.

## Why
**Clarity and Consistency**
- Improves documentation accuracy, reducing potential confusion regarding the error timeout configuration.
- Aligns the parameter name with the actual unit used in the system.

Let me know if any refinements are needed!