### PR TITLE
Update error timeout parameter in README from seconds to milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ These parameters define how the interface communicates with the Dynamixel motors
 
 - **`baud_rate`**: Communication baud rate.
 
-- **`error_timeout_sec`**: Timeout for communication errors.
+- **`error_timeout_ms`**: Timeout for communication errors.
 
 #### **2. Hardware Configuration**
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ These parameters define how the interface communicates with the Dynamixel motors
 
 - **`baud_rate`**: Communication baud rate.
 
-- **`error_timeout_ms`**: Timeout for communication errors.
+- **`error_timeout_ms`**: Timeout for communication errors (in milliseconds).
 
 #### **2. Hardware Configuration**
 


### PR DESCRIPTION
## Changes
'error_timeout_sec' parameter is deprecated, updating readme to use 'error_timeout_ms'.