### PR TITLE
Changed dynamixel_sdk_TARGETS to dynamixel_sdk_LIBRARIES in target_link_libraries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package dynamixel_hardware_interface
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.4.6 (2025-05-30)
+------------------
+* Changed dynamixel_sdk_TARGETS to dynamixel_sdk_LIBRARIES in target_link_libraries
+* Contributors: Woojin Wie
+
 1.4.5 (2025-05-30)
 ------------------
 * Deprecate ament_include_dependency usage in CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,8 @@ target_include_directories(
   ${PROJECT_NAME}
   PRIVATE
   include
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
   ${dynamixel_sdk_INCLUDE_DIRS}
   ${hardware_interface_INCLUDE_DIRS}
   ${realtime_tools_INCLUDE_DIRS}
@@ -53,7 +55,7 @@ target_link_libraries(${PROJECT_NAME}
   pluginlib::pluginlib
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
-  ${dynamixel_sdk_TARGETS}
+  ${dynamixel_sdk_LIBRARIES}
   ${std_srvs_TARGETS}
   ${dynamixel_interfaces_TARGETS}
   ${realtime_tools_TARGETS}

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>dynamixel_hardware_interface</name>
-  <version>1.4.5</version>
+  <version>1.4.6</version>
   <description>
     ROS 2 package providing a hardware interface for controlling Dynamixel motors via the ROS 2 control framework.
   </description>


### PR DESCRIPTION
Fixed build configuration for the legacy dynamixel_sdk user.