### PR TITLE
Read velocity_unit from model file otherwise use the existing default value

### DIFF
--- a/include/dynamixel_hardware_interface/dynamixel/dynamixel_info.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel/dynamixel_info.hpp
@@ -43,6 +43,7 @@ typedef  struct
   double torque_constant;
   double min_radian;
   double max_radian;
+  double velocity_unit = 0.01;  // default rpm per unit unless specified in model file
   int32_t value_of_zero_radian_position;
   int32_t value_of_max_radian_position;
   int32_t value_of_min_radian_position;
@@ -79,17 +80,18 @@ public:
     int32_t & value_of_min_radian_position,
     double & min_radian,
     double & max_radian,
-    double & torque_constant);
+    double & torque_constant,
+    double & velocity_unit);
   int32_t ConvertRadianToValue(uint8_t id, double radian);
   double ConvertValueToRadian(uint8_t id, int32_t value);
   inline int16_t ConvertEffortToCurrent(uint8_t id, double effort)
   {return static_cast<int16_t>(effort / dxl_info_[id].torque_constant);}
   inline double ConvertCurrentToEffort(uint8_t id, int16_t current)
   {return static_cast<double>(current * dxl_info_[id].torque_constant);}
-  inline double ConvertValueRPMToVelocityRPS(int32_t value_rpm)
-  {return static_cast<double>(value_rpm * 0.01 / 60.0 * 2.0 * M_PI);}
-  inline int32_t ConvertVelocityRPSToValueRPM(double vel_rps)
-  {return static_cast<int32_t>(vel_rps * 100.0 * 60.0 / 2.0 / M_PI);}
+  inline double ConvertValueRPMToVelocityRPS(uint8_t id, int32_t value_rpm)
+  {return static_cast<double>(value_rpm * dxl_info_[id].velocity_unit / 60.0 * 2.0 * M_PI);}
+  inline int32_t ConvertVelocityRPSToValueRPM(uint8_t id, double vel_rps)
+  {return static_cast<int32_t>(vel_rps * 60.0 / dxl_info_[id].velocity_unit / 2.0 / M_PI);}
 };
 
 }  // namespace dynamixel_hardware_interface

--- a/param/dxl_model/xh540_v150.model
+++ b/param/dxl_model/xh540_v150.model
@@ -5,6 +5,7 @@ value_of_max_radian_position	4095
 value_of_min_radian_position	0
 min_radian	-3.14159265
 max_radian	3.14159265
+velocity_unit	0.229
 
 [control table]
 Address	Size	Data Name

--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -1456,7 +1456,7 @@ DxlError Dynamixel::ProcessReadData(
         static_cast<int32_t>(dxl_getdata));
     } else if (item_names[item_index] == "Present Velocity") {
       *data_ptrs[item_index] =
-        dxl_info_.ConvertValueRPMToVelocityRPS(static_cast<int32_t>(dxl_getdata));
+        dxl_info_.ConvertValueRPMToVelocityRPS(id, static_cast<int32_t>(dxl_getdata));
     } else if (item_names[item_index] == "Present Current") {
       *data_ptrs[item_index] = dxl_info_.ConvertCurrentToEffort(
         id,
@@ -1628,7 +1628,7 @@ DxlError Dynamixel::SetDxlValueToSyncWrite()
         param_write_value[added_byte + 2] = DXL_LOBYTE(DXL_HIWORD(goal_position));
         param_write_value[added_byte + 3] = DXL_HIBYTE(DXL_HIWORD(goal_position));
       } else if (indirect_info_write_[ID].item_name.at(item_index) == "Goal Velocity") {
-        int16_t goal_velocity = dxl_info_.ConvertVelocityRPSToValueRPM(data);
+        int16_t goal_velocity = dxl_info_.ConvertVelocityRPSToValueRPM(ID, data);
         param_write_value[added_byte + 0] = DXL_LOBYTE(DXL_LOWORD(goal_velocity));
         param_write_value[added_byte + 1] = DXL_HIBYTE(DXL_LOWORD(goal_velocity));
         param_write_value[added_byte + 2] = DXL_LOBYTE(DXL_HIWORD(goal_velocity));
@@ -1847,7 +1847,7 @@ DxlError Dynamixel::SetDxlValueToBulkWrite()
           param_write_value[added_byte + 2] = DXL_LOBYTE(DXL_HIWORD(goal_position));
           param_write_value[added_byte + 3] = DXL_HIBYTE(DXL_HIWORD(goal_position));
         } else if (indirect_info_write_[ID].item_name.at(item_index) == "Goal Velocity") {
-          int32_t goal_velocity = dxl_info_.ConvertVelocityRPSToValueRPM(data);
+          int32_t goal_velocity = dxl_info_.ConvertVelocityRPSToValueRPM(ID, data);
           param_write_value[added_byte + 0] = DXL_LOBYTE(DXL_LOWORD(goal_velocity));
           param_write_value[added_byte + 1] = DXL_HIBYTE(DXL_LOWORD(goal_velocity));
           param_write_value[added_byte + 2] = DXL_LOBYTE(DXL_HIWORD(goal_velocity));

--- a/src/dynamixel/dynamixel_info.cpp
+++ b/src/dynamixel/dynamixel_info.cpp
@@ -74,6 +74,7 @@ void DynamixelInfo::ReadDxlModelFile(uint8_t id, uint16_t model_num)
 
   temp_dxl_info.model_num = model_num;
 
+  auto velocity_unit_found = false;
   while (!open_file.eof() ) {
     getline(open_file, line);
     if (strcmp(line.c_str(), "[control table]") == 0) {
@@ -100,12 +101,21 @@ void DynamixelInfo::ReadDxlModelFile(uint8_t id, uint16_t model_num)
         temp_dxl_info.max_radian = static_cast<double>(stod(strs.at(1)));
       } else if (strs.at(0) == "torque_constant") {
         temp_dxl_info.torque_constant = static_cast<double>(stod(strs.at(1)));
+      } else if (strs.at(0) == "velocity_unit") {
+        temp_dxl_info.velocity_unit = static_cast<double>(stod(strs.at(1)));
+        velocity_unit_found = true;
       }
     } catch (const std::exception & e) {
       std::string error_msg = "Error processing line in model file: " + line +
         "\nError: " + e.what();
       throw std::runtime_error(error_msg);
     }
+  }
+  if (!velocity_unit_found) {
+    fprintf(stdout,
+        "velocity_unit not explicitly set in model file for ID %i. "
+        "Using default value %f rpm per unit.\n",
+        id, temp_dxl_info.velocity_unit);
   }
 
   getline(open_file, line);
@@ -177,7 +187,8 @@ bool DynamixelInfo::GetDxlTypeInfo(
   int32_t & value_of_min_radian_position,
   double & min_radian,
   double & max_radian,
-  double & torque_constant)
+  double & torque_constant,
+  double & velocity_unit)
 {
   value_of_zero_radian_position = dxl_info_[id].value_of_zero_radian_position;
   value_of_max_radian_position = dxl_info_[id].value_of_max_radian_position;
@@ -185,6 +196,7 @@ bool DynamixelInfo::GetDxlTypeInfo(
   min_radian = dxl_info_[id].min_radian;
   max_radian = dxl_info_[id].max_radian;
   torque_constant = dxl_info_[id].torque_constant;
+  velocity_unit = dxl_info_[id].velocity_unit;
   return true;
 }
 


### PR DESCRIPTION
Hi,

I'm using a pair of xh540_v150 motors in velocity control mode for my differential drive robot's driving wheels. I noticed that my input twist messages were not matching the motor's output. After some debugging, I noticed that [a hardcoded velocity unit of 0.01 rpm per unit](https://github.com/ROBOTIS-GIT/dynamixel_hardware_interface/blob/main/include/dynamixel_hardware_interface/dynamixel/dynamixel_info.hpp#L90) was being used. However, for the abovementioned motor, this value should be 0.229 rpm per unit [as specified in the emanual](https://emanual.robotis.com/docs/en/dxl/x/xh540-v150/#goal-velocity104).

I am not sure how exactly these values are specified e.g., whether per firmware version or per motor model. But I noticed that currently some motors can have a different value. For example [for this motor](https://emanual.robotis.com/docs/en/dxl/rx/rx-24f/) it's 0.111 rpm per unit.

So it seemed to me that the best way to make these values  configurable is to read them from the model file. However, since there are many different model files already out there and I don't have a proper overview on all of them, I thought I keep it backward compatible. Hence, the default value is 0.01 (as it was before) unless specified in a model file (as I set it to 0.229 for xh540_v150). This way, existing configurations will remain stable and if needed, one can add their specific velocity_unit to a model file.