### PR TITLE
Support rising tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(realtime_tools REQUIRED)
 find_package(dynamixel_sdk REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(dynamixel_interfaces REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 ################################################################################
 # Build

--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -373,6 +373,12 @@ private:
 
   // Move dxl_comm_ to the end for safe destruction order
   std::shared_ptr<Dynamixel> dxl_comm_;
+
+  /**
+   * @brief Update homing offsets from the URDF model
+   * @return True if the offsets were updated successfully, false otherwise.
+   */
+  bool updateHomingOffsetsFromURDF();
 };
 
 // Conversion maps between ROS2 and Dynamixel interface names

--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -369,7 +369,11 @@ private:
     const std::unordered_map<std::string, std::vector<std::string>> & iface_map,
     const std::string & conversion_iface = "",
     const std::string & conversion_name = "",
-    std::function<double(double)> conversion = nullptr);
+    std::function<double(double)> conversion = nullptr,
+    bool outer_is_joint = false);
+
+  // Map of joint name -> rising offset (radians) read from URDF calibration
+  std::unordered_map<std::string, double> homing_offsets_;
 
   // Move dxl_comm_ to the end for safe destruction order
   std::shared_ptr<Dynamixel> dxl_comm_;

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>dynamixel_sdk</depend>
   <depend>std_srvs</depend>
   <depend>dynamixel_interfaces</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -1718,8 +1718,8 @@ bool DynamixelHardware::updateHomingOffsetsFromURDF(){
     if (calibration_element != nullptr) {
       const auto * rising_attr = calibration_element->FindAttribute("rising");
       if ((rising_attr != nullptr) && (name_attr != nullptr)) {
-        auto rising = std::atof(calibration_element->Attribute("rising"));
-        std::string name = joint_element->Attribute("name");
+        const auto rising = rising_attr->DoubleValue();
+        const std::string name = name_attr->Value();
         auto itr = std::find_if(
           info_.joints.begin(), info_.joints.end(),
           [&name](const hardware_interface::ComponentInfo & joint) { return joint.name == name; });

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -237,16 +237,14 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
           [&name](const hardware_interface::ComponentInfo & joint) {
             return joint.name == name;
           });
-        if (itr != info_.gpios.end()) {
-          auto params = info_.gpios[std::distance(info_.joints.begin(), itr)].parameters;
-          if (std::find_if(params.begin(), params.end(),
-              [](const std::pair<std::string, std::string> & p) {
-                return p.first == "Homing Offset";
-              }) == params.end())
+        if (itr != info_.joints.end()) {
+          const auto gpio_idx = std::distance(info_.joints.begin(), itr);
+          const auto& params = info_.gpios[gpio_idx].parameters;
+          if (params.find("Homing Offset") == params.end())
           {
-            info_.gpios[std::distance(info_.joints.begin(), itr)].parameters.emplace(
-              "Homing Offset",
-              std::to_string(std::round(rising * (180.0 / M_PI) / (360.0 / 4095))));
+          info_.gpios[gpio_idx].parameters.emplace(
+            "Homing Offset",
+            std::to_string(std::round(rising * (180.0 / M_PI) / (360.0 / 4095))));
           }
         }
       }

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -1727,8 +1727,13 @@ bool DynamixelHardware::updateHomingOffsetsFromURDF(){
           const auto gpio_idx = std::distance(info_.joints.begin(), itr);
           const auto & params = info_.gpios[gpio_idx].parameters;
           if (params.find("Homing Offset") == params.end()) {
+            constexpr double RAD_TO_DEG = 180.0 / M_PI;
+            constexpr double DXL_RESOLUTION_12BIT = 4095.0;
+            constexpr double DXL_MAX_DEG = 360.0;
+            const double homing_offset_steps =
+              std::round(rising * RAD_TO_DEG / (DXL_MAX_DEG / DXL_RESOLUTION_12BIT));
             info_.gpios[gpio_idx].parameters.emplace(
-              "Homing Offset", std::to_string(std::round(rising * (180.0 / M_PI) / (360.0 / 4095))));
+              "Homing Offset", std::to_string(homing_offset_steps));
           }
         }
       }

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -1316,7 +1316,8 @@ void DynamixelHardware::MapInterfaces(
   const std::unordered_map<std::string, std::vector<std::string>> & iface_map,
   const std::string & conversion_iface,
   const std::string & conversion_name,
-  std::function<double(double)> conversion)
+  std::function<double(double)> conversion,
+  bool outer_is_joint)
 {
   for (size_t i = 0; i < outer_size; ++i) {
     for (size_t k = 0; k < outer_handlers.at(i).interface_name_vec.size(); ++k) {
@@ -1346,7 +1347,14 @@ void DynamixelHardware::MapInterfaces(
             mapped_iface);
           if (it != inner_handlers.at(j).interface_name_vec.end()) {
             size_t idx = std::distance(inner_handlers.at(j).interface_name_vec.begin(), it);
-            value += matrix[i][j] * (*inner_handlers.at(j).value_ptr_vec.at(idx));
+            double inner_value = *inner_handlers.at(j).value_ptr_vec.at(idx);
+            if (!homing_offsets_.empty() && !outer_is_joint) {
+              auto hom_it = homing_offsets_.find(inner_handlers.at(j).name);
+              if (hom_it != homing_offsets_.end()) {
+                inner_value -= hom_it->second;
+              }
+            }
+            value += matrix[i][j] * inner_value;
             break;
           }
         }
@@ -1357,6 +1365,12 @@ void DynamixelHardware::MapInterfaces(
         conversion)
       {
         value = conversion(value);
+      }
+      if (!homing_offsets_.empty() && outer_is_joint) {
+        auto hom_it = homing_offsets_.find(outer_handlers.at(i).name);
+        if (hom_it != homing_offsets_.end()) {
+          value += hom_it->second;
+        }
       }
       *outer_handlers.at(i).value_ptr_vec.at(k) = value;
     }
@@ -1378,7 +1392,8 @@ void DynamixelHardware::CalcTransmissionToJoint()
     dynamixel_hardware_interface::ros2_to_dxl_state_map,
     hardware_interface::HW_IF_POSITION,
     conversion_joint_name_,
-    conv
+    conv,
+    true
   );
 }
 
@@ -1397,7 +1412,8 @@ void DynamixelHardware::CalcJointToTransmission()
     dynamixel_hardware_interface::dxl_to_ros2_cmd_map,
     "Goal Position",
     conversion_dxl_name_,
-    conv
+    conv,
+    false
   );
 }
 
@@ -1720,22 +1736,8 @@ bool DynamixelHardware::updateHomingOffsetsFromURDF(){
       if ((rising_attr != nullptr) && (name_attr != nullptr)) {
         const auto rising = rising_attr->DoubleValue();
         const std::string name = name_attr->Value();
-        auto itr = std::find_if(
-          info_.joints.begin(), info_.joints.end(),
-          [&name](const hardware_interface::ComponentInfo & joint) { return joint.name == name; });
-        if (itr != info_.joints.end()) {
-          const auto gpio_idx = std::distance(info_.joints.begin(), itr);
-          const auto & params = info_.gpios[gpio_idx].parameters;
-          if (params.find("Homing Offset") == params.end()) {
-            constexpr double RAD_TO_DEG = 180.0 / M_PI;
-            constexpr double DXL_RESOLUTION_12BIT = 4095.0;
-            constexpr double DXL_MAX_DEG = 360.0;
-            const double homing_offset_steps =
-              std::round(rising * RAD_TO_DEG / (DXL_MAX_DEG / DXL_RESOLUTION_12BIT));
-            info_.gpios[gpio_idx].parameters.emplace(
-              "Homing Offset", std::to_string(homing_offset_steps));
-          }
-        }
+        // Store rising offset (radians) per joint name in homing_offsets_
+        homing_offsets_[name] = rising;
       }
     }
     joint_element = joint_element->NextSiblingElement("joint");


### PR DESCRIPTION
- fix #96 

I updated the implementation so that when the URDF is parsed and a joint’s calibration rising value is present, it is applied to the Homing Offset parameter.