### PR TITLE
Support URDF calibration rising tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(realtime_tools REQUIRED)
 find_package(dynamixel_sdk REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(dynamixel_interfaces REQUIRED)
+find_package(tinyxml2_vendor REQUIRED)
 
 ################################################################################
 # Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ target_link_libraries(${PROJECT_NAME}
   ${std_srvs_TARGETS}
   ${dynamixel_interfaces_TARGETS}
   ${realtime_tools_TARGETS}
+  ${tinyxml2_vendor_TARGETS}
 )
 
 pluginlib_export_plugin_description_file(hardware_interface dynamixel_hardware_interface_plugin.xml)
@@ -109,6 +110,7 @@ ament_export_dependencies(
   pluginlib
   dynamixel_sdk
   dynamixel_interfaces
+  tinyxml2_vendor
 )
 
 ament_package()

--- a/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel_hardware_interface.hpp
@@ -370,10 +370,20 @@ private:
     const std::unordered_map<std::string, std::vector<std::string>> & iface_map,
     const std::string & conversion_iface = "",
     const std::string & conversion_name = "",
-    std::function<double(double)> conversion = nullptr);
+    std::function<double(double)> conversion = nullptr,
+    bool outer_is_joint = false);
+
+  // Map of joint name -> rising offset (radians) read from URDF calibration
+  std::unordered_map<std::string, double> homing_offsets_;
 
   // Move dxl_comm_ to the end for safe destruction order
   std::shared_ptr<Dynamixel> dxl_comm_;
+
+  /**
+   * @brief Update homing offsets from the URDF model
+   * @return True if the offsets were updated successfully, false otherwise.
+   */
+  bool updateHomingOffsetsFromURDF();
 };
 
 // Conversion maps between ROS2 and Dynamixel interface names

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <depend>dynamixel_sdk</depend>
   <depend>std_srvs</depend>
   <depend>dynamixel_interfaces</depend>
+  <depend>tinyxml2_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -1718,27 +1718,41 @@ std::string DynamixelHardware::getAllErrorSummaries() const
   return all_summaries.str();
 }
 
-bool DynamixelHardware::updateHomingOffsetsFromURDF(){
-  auto urdf = info_.original_xml;
+bool DynamixelHardware::updateHomingOffsetsFromURDF()
+{
+  const auto & urdf = info_.original_xml;
   tinyxml2::XMLDocument doc;
   if (doc.Parse(urdf.c_str()) != tinyxml2::XML_SUCCESS) {
     RCLCPP_ERROR(logger_, "Failed to parse URDF XML");
     return false;
   }
-  const auto * joint_element = doc.RootElement()->FirstChildElement("joint");
-  while (joint_element != nullptr) {
+
+  const auto * root_element = doc.RootElement();
+  if (!root_element) {
+    RCLCPP_WARN(logger_, "URDF is empty or has no root element. Skipping homing offset parsing.");
+    return true;
+  }
+
+  for (const auto * joint_element = root_element->FirstChildElement("joint");
+       joint_element != nullptr;
+       joint_element = joint_element->NextSiblingElement("joint"))
+  {
     const auto * name_attr = joint_element->FindAttribute("name");
-    const auto * calibration_element = joint_element->FirstChildElement("calibration");
-    if (calibration_element != nullptr) {
-      const auto * rising_attr = calibration_element->FindAttribute("rising");
-      if ((rising_attr != nullptr) && (name_attr != nullptr)) {
-        const auto rising = rising_attr->DoubleValue();
-        const std::string name = name_attr->Value();
-        // Store rising offset (radians) per joint name in homing_offsets_
-        homing_offsets_[name] = rising;
-      }
+    if (!name_attr) {
+      continue;
     }
-    joint_element = joint_element->NextSiblingElement("joint");
+
+    const auto * calibration_element = joint_element->FirstChildElement("calibration");
+    if (!calibration_element) {
+      continue;
+    }
+
+    const auto * rising_attr = calibration_element->FindAttribute("rising");
+    if (!rising_attr) {
+      continue;
+    }
+
+    homing_offsets_[name_attr->Value()] = rising_attr->DoubleValue();
   }
   return true;
 }

--- a/src/dynamixel_hardware_interface.cpp
+++ b/src/dynamixel_hardware_interface.cpp
@@ -16,6 +16,8 @@
 
 #include "dynamixel_hardware_interface/dynamixel_hardware_interface.hpp"
 
+#include <tinyxml2.h>
+
 #include <chrono>
 #include <cmath>
 #include <limits>
@@ -213,6 +215,10 @@ hardware_interface::CallbackReturn DynamixelHardware::on_init(
       }
       std::this_thread::sleep_for(std::chrono::milliseconds(250));
     }
+  }
+
+  if (!updateHomingOffsetsFromURDF()) {
+    return hardware_interface::CallbackReturn::ERROR;
   }
 
   torque_enabled_comm_id_id_.clear();
@@ -1308,7 +1314,8 @@ void DynamixelHardware::MapInterfaces(
   const std::unordered_map<std::string, std::vector<std::string>> & iface_map,
   const std::string & conversion_iface,
   const std::string & conversion_name,
-  std::function<double(double)> conversion)
+  std::function<double(double)> conversion,
+  bool outer_is_joint)
 {
   for (size_t i = 0; i < outer_size; ++i) {
     for (size_t k = 0; k < outer_handlers.at(i).interface_name_vec.size(); ++k) {
@@ -1338,7 +1345,14 @@ void DynamixelHardware::MapInterfaces(
             mapped_iface);
           if (it != inner_handlers.at(j).interface_name_vec.end()) {
             size_t idx = std::distance(inner_handlers.at(j).interface_name_vec.begin(), it);
-            value += matrix[i][j] * (*inner_handlers.at(j).value_ptr_vec.at(idx));
+            double inner_value = *inner_handlers.at(j).value_ptr_vec.at(idx);
+            if (!homing_offsets_.empty() && !outer_is_joint) {
+              auto hom_it = homing_offsets_.find(inner_handlers.at(j).name);
+              if (hom_it != homing_offsets_.end()) {
+                inner_value -= hom_it->second;
+              }
+            }
+            value += matrix[i][j] * inner_value;
             break;
           }
         }
@@ -1349,6 +1363,12 @@ void DynamixelHardware::MapInterfaces(
         conversion)
       {
         value = conversion(value);
+      }
+      if (!homing_offsets_.empty() && outer_is_joint) {
+        auto hom_it = homing_offsets_.find(outer_handlers.at(i).name);
+        if (hom_it != homing_offsets_.end()) {
+          value += hom_it->second;
+        }
       }
       *outer_handlers.at(i).value_ptr_vec.at(k) = value;
     }
@@ -1370,7 +1390,8 @@ void DynamixelHardware::CalcTransmissionToJoint()
     dynamixel_hardware_interface::ros2_to_dxl_state_map,
     hardware_interface::HW_IF_POSITION,
     conversion_joint_name_,
-    conv
+    conv,
+    true
   );
 }
 
@@ -1389,7 +1410,8 @@ void DynamixelHardware::CalcJointToTransmission()
     dynamixel_hardware_interface::dxl_to_ros2_cmd_map,
     "Goal Position",
     conversion_dxl_name_,
-    conv
+    conv,
+    false
   );
 }
 
@@ -1694,6 +1716,31 @@ std::string DynamixelHardware::getAllErrorSummaries() const
 
   all_summaries << "=====================================\n";
   return all_summaries.str();
+}
+
+bool DynamixelHardware::updateHomingOffsetsFromURDF(){
+  auto urdf = info_.original_xml;
+  tinyxml2::XMLDocument doc;
+  if (doc.Parse(urdf.c_str()) != tinyxml2::XML_SUCCESS) {
+    RCLCPP_ERROR(logger_, "Failed to parse URDF XML");
+    return false;
+  }
+  const auto * joint_element = doc.RootElement()->FirstChildElement("joint");
+  while (joint_element != nullptr) {
+    const auto * name_attr = joint_element->FindAttribute("name");
+    const auto * calibration_element = joint_element->FirstChildElement("calibration");
+    if (calibration_element != nullptr) {
+      const auto * rising_attr = calibration_element->FindAttribute("rising");
+      if ((rising_attr != nullptr) && (name_attr != nullptr)) {
+        const auto rising = rising_attr->DoubleValue();
+        const std::string name = name_attr->Value();
+        // Store rising offset (radians) per joint name in homing_offsets_
+        homing_offsets_[name] = rising;
+      }
+    }
+    joint_element = joint_element->NextSiblingElement("joint");
+  }
+  return true;
 }
 
 }  // namespace dynamixel_hardware_interface


### PR DESCRIPTION
This PR re-targets the work from #97 to `main`.

   - Parse URDF calibration `<calibration rising="..."/>` values for each joint on `on_init()` using TinyXML2
   - Apply the rising offset in the mapping phase (`MapInterfaces`) rather than writing it to the Homing Offset register on the servo:
     - **Transmission → Joint**: add the per-joint rising offset to the mapped position value
     - **Joint → Transmission**: subtract the per-joint rising offset from the actuator value before applying the transmission matrix