### PR TITLE
Support HX5-D20 XM335 devices on Humble

### DIFF
--- a/include/dynamixel_hardware_interface/dynamixel/dynamixel.hpp
+++ b/include/dynamixel_hardware_interface/dynamixel/dynamixel.hpp
@@ -215,7 +215,7 @@ private:
   dynamixel::GroupFastBulkRead * group_fast_bulk_read_ = nullptr;
 
   // fast read protocol state (applies to both sync and bulk)
-  bool use_fast_read_protocol_ = true;
+  bool use_fast_read_protocol_ = false;
   bool fast_read_permanent_ = false;
   int fast_read_fail_count_ = 0;
 

--- a/param/dxl_model/dynamixel.model
+++ b/param/dxl_model/dynamixel.model
@@ -77,7 +77,8 @@ Number	Name
 1240	xc330_m288.model
 1270	xw430_t333.model
 1310	xw540_h260.model
-1700	xc335_t332.model
+1700	xm335_t332.model
+1710	xm335_t323.model
 2000	ph42_020_s300.model
 2010	ph54_100_s500.model
 2020	ph54_200_s500.model

--- a/param/dxl_model/xm335_t323.model
+++ b/param/dxl_model/xm335_t323.model
@@ -1,0 +1,124 @@
+[unit info]
+Data Name	value	unit	Sign Type	Offset
+Present Velocity	0.0239691227	rad/s	signed	0.0
+Goal Velocity	0.0239691227	rad/s	signed	0.0
+Present Current	1.0	raw	signed	0.0
+Goal Current	1.0	raw	signed	0.0
+Present Position	0.0015339807878856412	rad	signed	-3.14159265359
+Goal Position	0.0015339807878856412	rad	signed	-3.14159265359
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+60	2	Startup Configuration
+62	1	PWM Slope
+63	1	Shutdown
+64	1	Torque Enable
+65	1	LED
+68	1	Status Return Level
+69	1	Registered Instruction
+70	1	Hardware Error Status
+76	2	Velocity I Gain
+78	2	Velocity P Gain
+80	2	Position D Gain
+82	2	Position I Gain
+84	2	Position P Gain
+88	2	Feedforward 2nd Gain
+90	2	Feedforward 1st Gain
+98	1	Bus Watchdog
+100	2	Goal PWM
+102	2	Goal Current
+104	4	Goal Velocity
+108	4	Profile Acceleration
+112	4	Profile Velocity
+116	4	Goal Position
+120	2	Realtime Tick
+122	1	Moving
+123	1	Moving Status
+124	2	Present PWM
+126	2	Present Current
+128	4	Present Velocity
+132	4	Present Position
+136	4	Velocity Trajectory
+140	4	Position Trajectory
+144	2	Present Input Voltage
+146	1	Present Temperature
+168	2	Indirect Address 1
+170	2	Indirect Address 2
+172	2	Indirect Address 3
+174	2	Indirect Address 4
+176	2	Indirect Address 5
+178	2	Indirect Address 6
+180	2	Indirect Address 7
+182	2	Indirect Address 8
+184	2	Indirect Address 9
+186	2	Indirect Address 10
+188	2	Indirect Address 11
+190	2	Indirect Address 12
+192	2	Indirect Address 13
+194	2	Indirect Address 14
+196	2	Indirect Address 15
+198	2	Indirect Address 16
+200	2	Indirect Address 17
+202	2	Indirect Address 18
+204	2	Indirect Address 19
+206	2	Indirect Address 20
+208	2	Indirect Address 21
+210	2	Indirect Address 22
+212	2	Indirect Address 23
+214	2	Indirect Address 24
+216	2	Indirect Address 25
+218	2	Indirect Address 26
+220	2	Indirect Address 27
+222	2	Indirect Address 28
+224	1	Indirect Data 1
+226	1	Indirect Data 2
+228	1	Indirect Data 3
+230	1	Indirect Data 4
+232	1	Indirect Data 5
+234	1	Indirect Data 6
+236	1	Indirect Data 7
+238	1	Indirect Data 8
+240	1	Indirect Data 9
+242	1	Indirect Data 10
+244	1	Indirect Data 11
+246	1	Indirect Data 12
+248	1	Indirect Data 13
+250	1	Indirect Data 14
+252	1	Indirect Data 15
+254	1	Indirect Data 16
+256	1	Indirect Data 17
+258	1	Indirect Data 18
+260	1	Indirect Data 19
+262	1	Indirect Data 20
+264	1	Indirect Data 21
+266	1	Indirect Data 22
+268	1	Indirect Data 23
+270	1	Indirect Data 24
+272	1	Indirect Data 25
+274	1	Indirect Data 26
+276	1	Indirect Data 27
+278	1	Indirect Data 28
+168	2	Indirect Address Write
+224	1	Indirect Data Write
+180	2	Indirect Address Read
+230	1	Indirect Data Read

--- a/param/dxl_model/xm335_t332.model
+++ b/param/dxl_model/xm335_t332.model
@@ -1,0 +1,124 @@
+[unit info]
+Data Name	value	unit	Sign Type	Offset
+Present Velocity	0.0239691227	rad/s	signed	0.0
+Goal Velocity	0.0239691227	rad/s	signed	0.0
+Present Current	1.0	raw	signed	0.0
+Goal Current	1.0	raw	signed	0.0
+Present Position	0.0015339807878856412	rad	signed	-3.14159265359
+Goal Position	0.0015339807878856412	rad	signed	-3.14159265359
+
+[control table]
+Address	Size	Data Name
+0	2	Model Number
+2	4	Model Information
+6	1	Firmware Version
+7	1	ID
+8	1	Baud Rate
+9	1	Return Delay Time
+10	1	Drive Mode
+11	1	Operating Mode
+12	1	Secondary(Shadow) ID
+13	1	Protocol Type
+20	4	Homing Offset
+24	4	Moving Threshold
+31	1	Temperature Limit
+32	2	Max Voltage Limit
+34	2	Min Voltage Limit
+36	2	PWM Limit
+38	2	Current Limit
+44	4	Velocity Limit
+48	4	Max Position Limit
+52	4	Min Position Limit
+60	2	Startup Configuration
+62	1	PWM Slope
+63	1	Shutdown
+64	1	Torque Enable
+65	1	LED
+68	1	Status Return Level
+69	1	Registered Instruction
+70	1	Hardware Error Status
+76	2	Velocity I Gain
+78	2	Velocity P Gain
+80	2	Position D Gain
+82	2	Position I Gain
+84	2	Position P Gain
+88	2	Feedforward 2nd Gain
+90	2	Feedforward 1st Gain
+98	1	Bus Watchdog
+100	2	Goal PWM
+102	2	Goal Current
+104	4	Goal Velocity
+108	4	Profile Acceleration
+112	4	Profile Velocity
+116	4	Goal Position
+120	2	Realtime Tick
+122	1	Moving
+123	1	Moving Status
+124	2	Present PWM
+126	2	Present Current
+128	4	Present Velocity
+132	4	Present Position
+136	4	Velocity Trajectory
+140	4	Position Trajectory
+144	2	Present Input Voltage
+146	1	Present Temperature
+168	2	Indirect Address 1
+170	2	Indirect Address 2
+172	2	Indirect Address 3
+174	2	Indirect Address 4
+176	2	Indirect Address 5
+178	2	Indirect Address 6
+180	2	Indirect Address 7
+182	2	Indirect Address 8
+184	2	Indirect Address 9
+186	2	Indirect Address 10
+188	2	Indirect Address 11
+190	2	Indirect Address 12
+192	2	Indirect Address 13
+194	2	Indirect Address 14
+196	2	Indirect Address 15
+198	2	Indirect Address 16
+200	2	Indirect Address 17
+202	2	Indirect Address 18
+204	2	Indirect Address 19
+206	2	Indirect Address 20
+208	2	Indirect Address 21
+210	2	Indirect Address 22
+212	2	Indirect Address 23
+214	2	Indirect Address 24
+216	2	Indirect Address 25
+218	2	Indirect Address 26
+220	2	Indirect Address 27
+222	2	Indirect Address 28
+224	1	Indirect Data 1
+226	1	Indirect Data 2
+228	1	Indirect Data 3
+230	1	Indirect Data 4
+232	1	Indirect Data 5
+234	1	Indirect Data 6
+236	1	Indirect Data 7
+238	1	Indirect Data 8
+240	1	Indirect Data 9
+242	1	Indirect Data 10
+244	1	Indirect Data 11
+246	1	Indirect Data 12
+248	1	Indirect Data 13
+250	1	Indirect Data 14
+252	1	Indirect Data 15
+254	1	Indirect Data 16
+256	1	Indirect Data 17
+258	1	Indirect Data 18
+260	1	Indirect Data 19
+262	1	Indirect Data 20
+264	1	Indirect Data 21
+266	1	Indirect Data 22
+268	1	Indirect Data 23
+270	1	Indirect Data 24
+272	1	Indirect Data 25
+274	1	Indirect Data 26
+276	1	Indirect Data 27
+278	1	Indirect Data 28
+168	2	Indirect Address Write
+224	1	Indirect Data Write
+180	2	Indirect Address Read
+230	1	Indirect Data Read

--- a/src/dynamixel/dynamixel.cpp
+++ b/src/dynamixel/dynamixel.cpp
@@ -1320,6 +1320,53 @@ DxlError Dynamixel::SetSyncReadHandler(std::vector<uint8_t> id_arr)
 
 DxlError Dynamixel::GetDxlValueFromSyncRead(double period_ms)
 {
+  if (read_data_list_.size() == 1) {
+    auto it_read_data = read_data_list_.front();
+    uint8_t id = it_read_data.comm_id;
+    uint16_t indirect_addr = indirect_info_read_[id].indirect_data_addr;
+    uint8_t indirect_size = indirect_info_read_[id].size;
+    std::vector<uint8_t> read_buffer(indirect_size, 0);
+    uint8_t dxl_error = 0;
+
+    if (period_ms > 0) {
+      port_handler_->setPacketTimeout(period_ms);
+    }
+
+    int dxl_comm_result = packet_handler_->readTxRx(
+      port_handler_, id, indirect_addr, indirect_size, read_buffer.data(), &dxl_error);
+    if (dxl_comm_result != COMM_SUCCESS) {
+      fprintf(
+        stderr, "DirectRead Rx Fail [ID : %d] [addr : %d] [size : %d] [Error code : %d]\n",
+        id, indirect_addr, indirect_size, dxl_comm_result);
+      return DxlError::SYNC_READ_FAIL;
+    }
+    if (dxl_error != 0) {
+      fprintf(
+        stderr, "DirectRead Packet Error [ID : %d] : %s\n",
+        id, packet_handler_->getRxPacketError(dxl_error));
+      return DxlError::SYNC_READ_FAIL;
+    }
+
+    return ProcessReadData(
+      id,
+      indirect_addr,
+      it_read_data.id_arr,
+      indirect_info_read_[id].item_name,
+      indirect_info_read_[id].item_size,
+      it_read_data.item_data_ptr_vec,
+      [&read_buffer, indirect_addr](uint8_t, uint16_t addr, uint8_t size) {
+        if (addr < indirect_addr) {
+          return uint32_t{0};
+        }
+        size_t offset = static_cast<size_t>(addr - indirect_addr);
+        uint32_t value = 0;
+        for (uint8_t i = 0; i < size && offset + i < read_buffer.size(); ++i) {
+          value |= static_cast<uint32_t>(read_buffer[offset + i]) << (8 * i);
+        }
+        return value;
+      });
+  }
+
   // Try fast sync read for the first 10 attempts after startup/handler setup.
   // If any of the first 10 attempts succeeds, use fast sync read permanently.
   // If all 10 attempts fail, permanently fallback to normal sync read.


### PR DESCRIPTION
## Summary

This adds the missing HX5-D20 XM335 model metadata needed by the ROS 2 Humble branch and adjusts the read path used during HX5-D20 bringup.

- Add model table entries for XM335-T332 and XM335-T323.
- Add `xm335_t332.model` and `xm335_t323.model` control table definitions.
- Avoid grouped sync-read handling for one-device read transactions by using direct `readTxRx`.
- Disable fast read by default for this Humble path.

## Why

While bringing up an HX5-D20 right hand on ROS 2 Humble, the Dynamixel hardware interface failed against the actual hardware even though DYNAMIXEL Wizard detected and controlled the full device chain correctly.

The observed device layout was:

- ID 110: HX5-D20-MRT
- IDs 111-114, 116-119, 121-124, 126-129, 131-134: XM335-T323
- IDs 115, 120, 125, 130, 135: HX-SENSOR-TIP

The Humble model list did not include model number `1710`, so the interface reported:

```text
Cannot find the DXL model from file list (model_num: 1710, model_name: unknown)
```

After adding the model definition, bringup progressed further but the HX5-D20-MRT read transaction still failed when the read group contained only ID 110:

```text
FastSyncRead Rx Fail [Dxl Size : 1] [Error code : -3001]
Dynamixel Read Fail
Dynamixel Write Fail
```

For the single-device MRT read case, direct protocol read succeeds and avoids requiring fast/group sync-read support from that one target.

## Impact

This allows the Humble branch to recognize the XM335-T323 devices used in HX5-D20 and avoids a bringup-time read failure on the HX5-D20-MRT controller path.

The existing grouped sync-read path remains used for multi-device reads.

## Validation

Built locally on ROS 2 Humble:

```bash
colcon build --symlink-install --packages-select dynamixel_hardware_interface robotis_hand_bringup robotis_hand_description robotis_hand_pressure_broadcaster --allow-overriding dynamixel_hardware_interface
```

Validated against an HX5-D20 right hand at 4 Mbps on `/dev/ttyUSB0`; the model table now resolves model `1710` as `xm335_t323.model`, and the bringup no longer stops at the missing-model or single-device fast sync read failure.
